### PR TITLE
Some typos and missing links fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pip install wandb_allennlp
     1. Create a sweep using a sweep config file. See `sweep_configs` directory for examples. Refer sweeps documentation [here](https://docs.wandb.ai/sweeps).
 
     ```
-    wandb sweep -e score-based-learning -p baselines sweep_configs/<path/to/config.yaml>
+    wandb sweep -e <your wandb account name or team name> -p baselines sweep_configs/<path/to/config.yaml>
 
     < you will see an alpha numeric sweep_id as output here. Copy it.>
     ```
@@ -81,6 +81,7 @@ pip install wandb_allennlp
 
     You can use `squeue` to see the running agents on nodes. You can rerun this command to start more agents.
 
+5. Running Example
 
 # Directory Structure
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ pip install wandb_allennlp
         export TEST=1
         export CUDA_DEVICE=-1
         allennlp train <path_to_config> -s <path to serialization dir> --include-package structured_prediction_baselines
+	e.g. allennlp train ./model_configs/multilabel_classification/bibtex_basic_ovf_loss.jsonnet -s ./serial_path --include-package structured_prediction_baselines
         ```
 
         2. With output to wandb (see [creating account and login into wandb](https://docs.wandb.ai/quickstart#2-create-account) for details on getting started with wandb.)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pip install wandb_allennlp
     1. Create a sweep using a sweep config file. See `sweep_configs` directory for examples. Refer sweeps documentation [here](https://docs.wandb.ai/sweeps).
 
     ```
-    wandb sweep -e score-based-learning -p baselines sweep_configs/path/to/config.yaml
+    wandb sweep -e score-based-learning -p baselines sweep_configs/path/to/config.yaml #여기서 -e를 내 id로 설정해야 함
 
     < you will see an alpha numeric sweep_id as output here. Copy it.>
     ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pip install wandb_allennlp
     1. Create a sweep using a sweep config file. See `sweep_configs` directory for examples. Refer sweeps documentation [here](https://docs.wandb.ai/sweeps).
 
     ```
-    wandb sweep -e score-based-learning -p baselines sweep_configs/path/to/config.yaml #여기서 -e를 내 id로 설정해야 함
+    wandb sweep -e score-based-learning -p baselines sweep_configs/path/to/config.yaml
 
     < you will see an alpha numeric sweep_id as output here. Copy it.>
     ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pip install wandb_allennlp
         export TEST=1
         export CUDA_DEVICE=-1
         allennlp train <path_to_config> -s <path to serialization dir> --include-package structured_prediction_baselines
-	e.g. allennlp train ./model_configs/multilabel_classification/bibtex_basic_ovf_loss.jsonnet -s ./serial_path --include-package structured_prediction_baselines
+
         ```
 
         2. With output to wandb (see [creating account and login into wandb](https://docs.wandb.ai/quickstart#2-create-account) for details on getting started with wandb.)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install wandb_allennlp
         ```
         export TEST=1
         export CUDA_DEVICE=-1
-        allennlp train <path_to_config> -s <path to serialization dir> --include_package structured_prediction_baselines
+        allennlp train <path_to_config> -s <path to serialization dir> --include-package structured_prediction_baselines
         ```
 
         2. With output to wandb (see [creating account and login into wandb](https://docs.wandb.ai/quickstart#2-create-account) for details on getting started with wandb.)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pip install wandb_allennlp
     export CUDA_DEVICE=0 # 0 for GPU, -1 for CPU
     export TEST=1 # for a dryrun and without uploading results to wandb
     export WANDB_IGNORE_GLOBS=*\*\*\*.th,*\*\*\*.tar.gz,*\*\*.th,*\*\*.tar.gz,*\*.th,*\*.tar.gz,*.tar.gz,*.th
+    export DATA_DIR="./data/"
     ```
 
 3. Training single models
@@ -58,7 +59,7 @@ pip install wandb_allennlp
         ```
         export TEST=0
         export CUDA_DEVICE=-1
-        wandb_allennlp --subcommand=train --config_file=model_configs/<path_to_config_file> --include-package=structured_prediction_baselines --wandb_run_name=<some_informative_name_for_run>  --wandb_project structured_prediction_baselines --wandb_entity score-based-learning --wandb_tags=baselines,as_reported
+        allennlp train-with-wandb --config_file=model_configs/<path_to_config_file> --include-package=structured_prediction_baselines --wandb_run_name=<some_informative_name_for_run>  --wandb_project structured_prediction_baselines --wandb_entity <your wandb account name or team name> -- some hyperparameters to add (please refer to 5)
         ```
 
 4. Running hyperparameter sweeps
@@ -66,7 +67,7 @@ pip install wandb_allennlp
     1. Create a sweep using a sweep config file. See `sweep_configs` directory for examples. Refer sweeps documentation [here](https://docs.wandb.ai/sweeps).
 
     ```
-    wandb sweep -e score-based-learning -p baselines sweep_configs/path/to/config.yaml
+    wandb sweep -e score-based-learning -p baselines sweep_configs/<path/to/config.yaml>
 
     < you will see an alpha numeric sweep_id as output here. Copy it.>
     ```
@@ -75,10 +76,11 @@ pip install wandb_allennlp
 
     ```
     export TEST=0
-    python slurm_wandb_agent.py <sweep_id> -p baselines -e score-based-learning --num-jobs 5 -f --edit-sbatch --edit-srun
+    python slurm_wandb_agent.py <sweep_id> -p baselines -e <your wandb account name or team name> --num-jobs 5 -f --edit-sbatch --edit-srun
     ```
 
     You can use `squeue` to see the running agents on nodes. You can rerun this command to start more agents.
+
 
 # Directory Structure
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pip install wandb_allennlp
         ```
         export TEST=0
         export CUDA_DEVICE=-1
-        allennlp train-with-wandb --config_file=model_configs/<path_to_config_file> --include-package=structured_prediction_baselines --wandb_run_name=<some_informative_name_for_run>  --wandb_project structured_prediction_baselines --wandb_entity <your wandb account name or team name> -- some hyperparameters to add (please refer to 5)
+        allennlp train-with-wandb --config_file=model_configs/<path_to_config_file> --include-package=structured_prediction_baselines --wandb_run_name=<some_informative_name_for_run>  --wandb_project structured_prediction_baselines --wandb_entity <your wandb account name or team name> -- some hyperparameters to add
         ```
 
 4. Running hyperparameter sweeps
@@ -71,7 +71,8 @@ pip install wandb_allennlp
 
     < you will see an alpha numeric sweep_id as output here. Copy it.>
     ```
-
+    NOTE: some sweep config files use old allennlp command (e.g. 'allennlp train_with_wandb' or 'wandb_allenlp --subvommand=train'). please make sure your sweep config file is up to date as 3.
+    
     2. Start search agent on slurm using the following (This script will internally submit to sbatch. So you can run this command on the head node eventhough it is a python script because it exit withing seconds.)
 
     ```
@@ -81,7 +82,8 @@ pip install wandb_allennlp
 
     You can use `squeue` to see the running agents on nodes. You can rerun this command to start more agents.
 
-5. Running Example
+
+
 
 # Directory Structure
 

--- a/download_datasets.sh
+++ b/download_datasets.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 # CONLL 2003 NER
 mkdir -p data/conll2003ner
-wget https://raw.githubusercontent.com/davidsbatista/NER-datasets/master/CONLL2003/train.txt -O data/conll2003ner/train.txt
-wget https://raw.githubusercontent.com/davidsbatista/NER-datasets/master/CONLL2003/valid.txt -O data/conll2003ner/val.txt
-wget https://raw.githubusercontent.com/davidsbatista/NER-datasets/master/CONLL2003/test.txt -O data/conll2003ner/test.txt
+cd data/conll2003ner
+wget https://data.deepai.org/conll2003.zip
+unzip conll2003.zip
+
+# Github link below has been deleted because of copyright issues
+#wget https://raw.githubusercontent.com/davidsbatista/NER-datasets/master/CONLL2003/train.txt -O data/conll2003ner/train.txt
+#wget https://raw.githubusercontent.com/davidsbatista/NER-datasets/master/CONLL2003/valid.txt -O data/conll2003ner/val.txt
+#wget https://raw.githubusercontent.com/davidsbatista/NER-datasets/master/CONLL2003/test.txt -O data/conll2003ner/test.txt
 
 # Bibtex 7395 1836 159 card: 2.4
 mkdir -p data/bibtex_original

--- a/download_datasets.sh
+++ b/download_datasets.sh
@@ -1,11 +1,13 @@
-#!/bin/bash
 # CONLL 2003 NER
 mkdir -p data/conll2003ner
 cd data/conll2003ner
 wget https://data.deepai.org/conll2003.zip
 unzip conll2003.zip
+rm conll2003.zip
+cd ../..
 
 # Github link below has been deleted because of copyright issues
+# For detailed information, please refer to this link: https://github.com/huggingface/datasets/issues/3582
 #wget https://raw.githubusercontent.com/davidsbatista/NER-datasets/master/CONLL2003/train.txt -O data/conll2003ner/train.txt
 #wget https://raw.githubusercontent.com/davidsbatista/NER-datasets/master/CONLL2003/valid.txt -O data/conll2003ner/val.txt
 #wget https://raw.githubusercontent.com/davidsbatista/NER-datasets/master/CONLL2003/test.txt -O data/conll2003ner/test.txt

--- a/sweep_configs/multilabel_classification/v2.5/bibtex_strat/bibtex_strat_dvn.yaml
+++ b/sweep_configs/multilabel_classification/v2.5/bibtex_strat/bibtex_strat_dvn.yaml
@@ -3,10 +3,9 @@ description: "Original DVN."
 program: allennlp
 command:
 - ${program}
-- train_with_wandb
+- train-with-wandb
 - model_configs/multilabel_classification/v2.5/gendata_dvn.jsonnet
 - --include-package=structured_prediction_baselines
-- --wandb_tags=task=mlc,model=dvn,sampler=gbi+adv+gt,dataset=bibtex_strat,inference_module=gbi,inference_module=gbi,sampler=gbi+adv+gt
 - ${args}
 - --file-friendly-logging
 method: bayes


### PR DESCRIPTION
Hi. I'm Jong Song, a graduate student whose PI is Dr. Jay-yoon Lee

While running SEAL code, I have found some issues with codes and fixed them.

1. A typo on Readme.md
The code 'allennlp train <path_to_config> -s <path to serialization dir> --include_package structured_prediction_baselines' does not work as there is no argument 'include_package' for allennlp training. It should be modified to 'include-package' instead (I hope you can find the difference between them)

2. Download link for conll 2003 dataset has been expired
Unfortunately, the download link for conll 2003 on download_datasets.sh has expired. (for more detail, please refer to this thread: https://github.com/huggingface/datasets/issues/3582) I changed it to a valid one.
